### PR TITLE
Improve responsive layout for home sections

### DIFF
--- a/components/About.jsx
+++ b/components/About.jsx
@@ -50,7 +50,7 @@ const expData = [
 const About = () => {
   
   return (
-    <section className="xl:h-[660px] pb-0 sm:pb-12 -mb-80 sm:-mb-0 xl:py-24 flex-col justify-center items-center mx-auto ">
+    <section className="py-12 sm:py-16 xl:py-24 flex-col justify-center items-center mx-auto">
       <div className="container mx-auto">
         <h2 className="section-title text-center  mb-8 xl:mb-16 mx-auto">
           About Me

--- a/components/Hero.jsx
+++ b/components/Hero.jsx
@@ -11,9 +11,9 @@ import Image from "next/image";
 
 const Hero = () => {
   return (
-    <section className="py-0 sm:py-12 xl:py-24 h-[84vh] xl:pt-28 -mb-40 sm:-mb-0">
+    <section className="pt-20 sm:pt-24 xl:pt-28 pb-12 sm:pb-16">
       <div className="container mx-auto">
-        <div className="flex justify-between gap-x-8">
+        <div className="flex flex-col xl:flex-row justify-between gap-12 xl:gap-x-8">
           <div className="flex max-w-[600px] flex-col justify-center mx-auto xl:mx-0 text-center xl:text-left">
             <div className="text-sm uppercase font-semibold mb-4 text-primary tracking-[4px]">
               Software Developer
@@ -106,7 +106,7 @@ const Hero = () => {
             </div>
           </div>
         </div>
-        <div className="hidden md:flex absolute xl:bottom-10 left-1/2  animate-bounce  ">
+        <div className="hidden md:flex absolute xl:bottom-10 left-1/2 animate-bounce">
           <RiArrowDownSLine className="text-4xl text-primary mx-auto pr-3 " />
         </div>
       </div>

--- a/components/MacScroll.jsx
+++ b/components/MacScroll.jsx
@@ -109,17 +109,16 @@ export const MacbookScroll = ({ src, showGradient, title, badge }) => {
   return (
     <div
       ref={ref}
-      className="min-h-[200vh] flex flex-col items-center 
-      py-0 md:py-40 justify-start flex-shrink-0 
-      [perspective:800px] transform md:scale-100 
-      scale-[0.5] sm:scale-75 "
+      className="min-h-[180vh] sm:min-h-[200vh] flex flex-col items-center 
+      py-12 sm:py-20 lg:py-32 justify-start flex-shrink-0 
+      [perspective:800px] transform px-4"
     >
       <motion.h2
         style={{
           translateY: textTransform,
           opacity: textOpacity,
         }}
-        className="dark:text-white text-neutral-800 text-5xl font-bold mb-20 text-center"
+        className="dark:text-white text-neutral-800 text-3xl sm:text-4xl lg:text-5xl font-bold mb-10 sm:mb-16 text-center"
       >
         {title || (
           <span>
@@ -136,7 +135,10 @@ export const MacbookScroll = ({ src, showGradient, title, badge }) => {
         translate={translate}
       />
       {/* Base area */}
-      <div className="h-[22rem] w-[32rem] bg-[#272729] rounded-2xl overflow-hidden relative -z-10">
+      <div
+        className="w-full max-w-[32rem] bg-[#272729] rounded-2xl overflow-hidden relative -z-10"
+        style={{ height: "min(22rem, 60vw)" }}
+      >
         {/* above keyboard bar */}
         <div className="h-10 w-full relative">
           <div className="absolute inset-x-0 mx-auto w-[80%] h-4 bg-[#050505]" />
@@ -165,14 +167,19 @@ export const MacbookScroll = ({ src, showGradient, title, badge }) => {
 
 export const Lid = ({ scaleX, scaleY, rotate, translate, src }) => {
   return (
-    <div className="relative [perspective:800px]">
+    <div
+      className="relative [perspective:800px] mx-auto"
+      style={{ width: "min(32rem, 90vw)", height: "min(24rem, 70vw)" }}
+    >
       <div
         style={{
           transform: "perspective(800px) rotateX(-25deg) translateZ(0px)",
           transformOrigin: "bottom",
           transformStyle: "preserve-3d",
+          width: "100%",
+          height: "min(12rem, 36vw)",
         }}
-        className="h-[12rem] w-[32rem] bg-[#010101] rounded-2xl p-2 relative"
+        className="bg-[#010101] rounded-2xl p-2 relative"
       >
         <div
           style={{
@@ -195,7 +202,7 @@ export const Lid = ({ scaleX, scaleY, rotate, translate, src }) => {
           transformStyle: "preserve-3d",
           transformOrigin: "top",
         }}
-        className="h-96 w-[32rem] absolute inset-0 bg-[#010101] rounded-2xl p-2"
+        className="absolute inset-0 bg-[#010101] rounded-2xl p-2"
       >
         <div className="absolute inset-0 bg-[#272729] rounded-lg" />
         <Image
@@ -212,7 +219,7 @@ export const Lid = ({ scaleX, scaleY, rotate, translate, src }) => {
 export const Trackpad = () => {
   return (
     <div
-      className="w-[40%] mx-auto h-32  rounded-xl my-1"
+      className="w-[45%] mx-auto h-24 sm:h-28 rounded-xl my-1"
       style={{
         boxShadow: "0px 0px 1px 1px #00000020 inset",
       }}

--- a/components/Skills.jsx
+++ b/components/Skills.jsx
@@ -2,12 +2,16 @@ import { MacbookScroll } from './MacScroll'
 
 const Skills = () => {
   return (
-    <section className='xl:h-[2660px] md:h-[2660px] sm:h-[1000px] pb-12  flex-col justify-center items-center mx-auto'>
-        <div className="container mx-auto">
-        <MacbookScroll title="Powering My Projects" showGradient={true} src={"/Skills.png"}/>
-        </div>
+    <section className="py-12 sm:py-16 lg:py-24 flex-col justify-center items-center mx-auto">
+      <div className="container mx-auto">
+        <MacbookScroll
+          title="Powering My Projects"
+          showGradient={true}
+          src={"/Skills.png"}
+        />
+      </div>
     </section>
-  )
+  );
 }
 
 export default Skills


### PR DESCRIPTION
### Motivation

- Fix layout and overflow issues on small and medium screens, with special attention to the Macbook scroll component which previously used fixed sizes and caused scrolling/overflow problems. 
- Make Hero, About and Skills sections stack and space correctly across breakpoints instead of relying on fixed heights and negative margins.

### Description

- Reworked `components/MacScroll.jsx` to use responsive container sizing and spacing by replacing fixed widths/heights with `max-w`, `min()` sizing and viewport-relative heights, adjusted `Lid` sizing and scale behavior, and reduced oversized default scales and paddings. 
- Adjusted the Macbook `Trackpad` size to be smaller on narrow viewports and updated the overall Mac scroll wrapper (`min-h`, `py`, `px`) to avoid overflow on mobile. 
- Updated `components/Hero.jsx` to remove the fixed `h-[84vh]` and negative margins and to stack the layout (`flex-col` on small screens, `xl:flex-row` on large screens) with responsive paddings. 
- Updated `components/About.jsx` and `components/Skills.jsx` to replace fixed/negative heights with responsive paddings so sections grow naturally on different screen sizes.

### Testing

- Started the dev server with `npm run dev` and the app compiled successfully. 
- Ran an automated Playwright script that visited the homepage and captured screenshots for desktop and mobile viewports, producing `artifacts/home-desktop.png` and `artifacts/home-mobile.png`, and the second run completed successfully after an initial timeout. 
- No unit tests were present or run for these UI changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69822f5439688330bfb99729c6b2720c)